### PR TITLE
Pie chart performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx1G
     mapping_version=2023.09.03
 
 # Mod Properties
-    mod_version=3.0.0
+    mod_version=3.0.1
     maven_group=com.rubenverg.gtmoleculedrawings
     archives_base_name=gtmoldraw
     mod_id=moldraw

--- a/src/main/java/com/rubenverg/moldraw/component/AlloyTooltipComponent.java
+++ b/src/main/java/com/rubenverg/moldraw/component/AlloyTooltipComponent.java
@@ -117,8 +117,13 @@ public record AlloyTooltipComponent(List<Pair<Material, Long>> rawComponents) im
                 c.add(new Pair<>(current, comp.getA()));
                 current += comp.getB();
             }
-            stops = s.stream().map(pair -> new Pair<>(Math.PI * 2 * pair.getA() / total, pair.getB())).toList();
-
+            stops = new ArrayList<>(components.size());
+            double offset = 0;
+            for (var comp : components) {
+                double end = offset +  Math.PI * 2 * comp.getB()/(double)total;
+                stops.add(new Pair<>(end, comp.getA()));
+                offset = end;
+            }
             c.remove(0);
             c.add(new Pair<>(total, GTMaterials.NULL));
             centers = Streams
@@ -178,19 +183,7 @@ public record AlloyTooltipComponent(List<Pair<Material, Long>> rawComponents) im
         public void renderImage(Font font, int x, int y, GuiGraphics guiGraphics) {
             final int xm = BASE_WIDTH / 2 + addLeft + x, ym = baseHeight / 2 + addTop + y;
 
-            final IntBinaryOperator sc = (xp, yp) -> {
-                final int rx = xp - xm, ry = yp - ym;
-                final double ng = Math.atan2(rx, -ry);
-                final double angle = ng < 0 ? ng + 2 * Math.PI : ng;
-                for (int si = 1; si <= stops.size(); si++) {
-                    if (angle <= stops.get(si % stops.size()).getA())
-                        return MoleculeColorize.colorForMaterial(stops.get(si - 1).getB());
-                }
-                return MoleculeColorize.colorForMaterial(stops.get(stops.size() - 1).getB());
-            };
-
-            GraphicalUtils.plotCircle(xm, ym, MolDrawConfig.INSTANCE.alloy.pieChartRadius, GraphicalUtils::alwaysDraw,
-                    sc, guiGraphics);
+            GraphicalUtils.plotPieChart(xm, ym, MolDrawConfig.INSTANCE.alloy.pieChartRadius, stops, guiGraphics);
 
             final IntBinaryOperator white = (_xp, _yp) -> 0xffffffff;
 

--- a/src/main/java/com/rubenverg/moldraw/component/AlloyTooltipComponent.java
+++ b/src/main/java/com/rubenverg/moldraw/component/AlloyTooltipComponent.java
@@ -120,7 +120,7 @@ public record AlloyTooltipComponent(List<Pair<Material, Long>> rawComponents) im
             stops = new ArrayList<>(components.size());
             double offset = 0;
             for (var comp : components) {
-                double end = offset +  Math.PI * 2 * comp.getB()/(double)total;
+                double end = offset + Math.PI * 2 * comp.getB() / (double) total;
                 stops.add(new Pair<>(end, comp.getA()));
                 offset = end;
             }

--- a/src/main/java/com/rubenverg/moldraw/component/GraphicalUtils.java
+++ b/src/main/java/com/rubenverg/moldraw/component/GraphicalUtils.java
@@ -1,11 +1,17 @@
 package com.rubenverg.moldraw.component;
 
+import com.gregtechceu.gtceu.api.data.chemical.material.Material;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.rubenverg.moldraw.MoleculeColorize;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.client.gui.GuiGraphics;
-
-import java.util.function.IntBinaryOperator;
+import net.minecraft.client.renderer.RenderType;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
+import java.util.function.IntBinaryOperator;
+import org.joml.Matrix4f;
+import oshi.util.tuples.Pair;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
@@ -89,5 +95,50 @@ public class GraphicalUtils {
     public static void plotCircle(int xm, int ym, int r, PixelPredicate shouldDraw, IntBinaryOperator color,
                                   GuiGraphics graphics) {
         plotCircle(xm, ym, r, shouldDraw, (xp, yp) -> graphics.fill(xp, yp, xp + 1, yp + 1, color.applyAsInt(xp, yp)));
+    }
+
+    private static void plotPieChartSection(int xm, int ym, int r, double start, double end, int color, VertexConsumer consumer, Matrix4f matrix) {
+        //Can be adjusted for smoother circle, maybe config?
+        double stepsPerArcLength = 8;
+        double arcLength;
+        if(end > start) {
+            arcLength = end - start;
+        } else {
+            //in case it wraps around back to the beginning
+            arcLength = (Math.PI * 2 + end) - start;
+        }
+        int steps = (int) (arcLength * stepsPerArcLength) + 1;
+        double stepSize = (end-start)/steps;
+
+        double lastX = xm + Math.sin(start) * r;
+        double lastY = ym - Math.cos(start) * r;
+        for (int i = 1; i <= steps; i++) {
+            double currentAngle = start + stepSize * i;
+
+            double currentX = xm + Math.sin(currentAngle) * r;
+            double currentY = ym - Math.cos(currentAngle) * r;
+
+            consumer.vertex(matrix, (float)lastX, (float)lastY, 0).color(color).endVertex();
+            //degenerate vertex because minecraft wants quads to render instead of triangles
+            consumer.vertex(matrix, (float)xm, (float)ym, 0).color(color).endVertex();
+            consumer.vertex(matrix, (float)xm, (float)ym, 0).color(color).endVertex();
+            consumer.vertex(matrix, (float)currentX, (float)currentY, 0).color(color).endVertex();
+
+            lastX = currentX;
+            lastY = currentY;
+        }
+    }
+
+    public static void plotPieChart(int xm, int ym, int r, List<Pair<Double, Material>> stops, GuiGraphics graphics) {
+        final VertexConsumer buffer = graphics.bufferSource().getBuffer(RenderType.gui());
+
+        final Matrix4f matrix = graphics.pose().last().pose();
+
+        final int size = stops.size();
+        for (int i = 0; i < size; i++) {
+            double start = i==0?0:stops.get(i-1).getA();
+            double end = stops.get(i).getA();
+            plotPieChartSection(xm, ym, r, start, end, MoleculeColorize.colorForMaterial(stops.get(i).getB()), buffer, matrix);
+        }
     }
 }

--- a/src/main/java/com/rubenverg/moldraw/component/GraphicalUtils.java
+++ b/src/main/java/com/rubenverg/moldraw/component/GraphicalUtils.java
@@ -1,17 +1,20 @@
 package com.rubenverg.moldraw.component;
 
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
-import com.mojang.blaze3d.vertex.VertexConsumer;
-import com.rubenverg.moldraw.MoleculeColorize;
+
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.RenderType;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.List;
-import java.util.function.IntBinaryOperator;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.rubenverg.moldraw.MoleculeColorize;
 import org.joml.Matrix4f;
 import oshi.util.tuples.Pair;
+
+import java.util.List;
+import java.util.function.IntBinaryOperator;
+
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
@@ -97,18 +100,19 @@ public class GraphicalUtils {
         plotCircle(xm, ym, r, shouldDraw, (xp, yp) -> graphics.fill(xp, yp, xp + 1, yp + 1, color.applyAsInt(xp, yp)));
     }
 
-    private static void plotPieChartSection(int xm, int ym, int r, double start, double end, int color, VertexConsumer consumer, Matrix4f matrix) {
-        //Can be adjusted for smoother circle, maybe config?
+    private static void plotPieChartSection(int xm, int ym, int r, double start, double end, int color,
+                                            VertexConsumer consumer, Matrix4f matrix) {
+        // Can be adjusted for smoother circle, maybe config?
         double stepsPerArcLength = 8;
         double arcLength;
-        if(end > start) {
+        if (end > start) {
             arcLength = end - start;
         } else {
-            //in case it wraps around back to the beginning
+            // in case it wraps around back to the beginning
             arcLength = (Math.PI * 2 + end) - start;
         }
         int steps = (int) (arcLength * stepsPerArcLength) + 1;
-        double stepSize = (end-start)/steps;
+        double stepSize = (end - start) / steps;
 
         double lastX = xm + Math.sin(start) * r;
         double lastY = ym - Math.cos(start) * r;
@@ -118,11 +122,11 @@ public class GraphicalUtils {
             double currentX = xm + Math.sin(currentAngle) * r;
             double currentY = ym - Math.cos(currentAngle) * r;
 
-            consumer.vertex(matrix, (float)lastX, (float)lastY, 0).color(color).endVertex();
-            //degenerate vertex because minecraft wants quads to render instead of triangles
-            consumer.vertex(matrix, (float)xm, (float)ym, 0).color(color).endVertex();
-            consumer.vertex(matrix, (float)xm, (float)ym, 0).color(color).endVertex();
-            consumer.vertex(matrix, (float)currentX, (float)currentY, 0).color(color).endVertex();
+            consumer.vertex(matrix, (float) lastX, (float) lastY, 0).color(color).endVertex();
+            // degenerate vertex because minecraft wants quads to render instead of triangles
+            consumer.vertex(matrix, (float) xm, (float) ym, 0).color(color).endVertex();
+            consumer.vertex(matrix, (float) xm, (float) ym, 0).color(color).endVertex();
+            consumer.vertex(matrix, (float) currentX, (float) currentY, 0).color(color).endVertex();
 
             lastX = currentX;
             lastY = currentY;
@@ -136,9 +140,10 @@ public class GraphicalUtils {
 
         final int size = stops.size();
         for (int i = 0; i < size; i++) {
-            double start = i==0?0:stops.get(i-1).getA();
+            double start = i == 0 ? 0 : stops.get(i - 1).getA();
             double end = stops.get(i).getA();
-            plotPieChartSection(xm, ym, r, start, end, MoleculeColorize.colorForMaterial(stops.get(i).getB()), buffer, matrix);
+            plotPieChartSection(xm, ym, r, start, end, MoleculeColorize.colorForMaterial(stops.get(i).getB()), buffer,
+                    matrix);
         }
     }
 }


### PR DESCRIPTION
Noticed that when i looked at a pie chart with lots of components(eg topaz dust from tfg), the garbage collector gets sad and the game gets 0 fps. This pr fixes that.

Previously the pie chart was drawn pixel by pixel, each pixel allocating some capturing lambdas(also a draw call per pixel)(Edit: it might have just been per line rather than per pixel). This instead breaks the pie chart into sections, and then draws a triangle fan from it. Many fewer draw calls and no allocations from lambdas